### PR TITLE
Upload JAR indexes to S3

### DIFF
--- a/src/main/scala/com/virtuslab/shared_indexes/config/JarIndexesConfig.scala
+++ b/src/main/scala/com/virtuslab/shared_indexes/config/JarIndexesConfig.scala
@@ -1,0 +1,10 @@
+package com.virtuslab.shared_indexes.config
+
+import mainargs.Flag
+
+// These flags are needed because mainargs doesn't support nested subcommands
+// See https://github.com/com-lihaoyi/mainargs/issues/57
+case class JarIndexesConfig(
+    upload: Flag,
+    download: Flag
+)

--- a/src/main/scala/com/virtuslab/shared_indexes/config/MainConfig.scala
+++ b/src/main/scala/com/virtuslab/shared_indexes/config/MainConfig.scala
@@ -10,7 +10,8 @@ case class MainConfig(
     indexStorageConfig: IndexStorageConfig,
     indexInputConfig: IndexInputConfig,
     s3Config: S3Config,
-    loggingConfig: LoggingConfig
+    loggingConfig: LoggingConfig,
+    jarIndexesConfig: JarIndexesConfig
 )
 
 object MainConfig {
@@ -52,5 +53,6 @@ object MainConfig {
   private implicit val indexInputConfigReader: TokensReader[IndexInputConfig] = ParserForClass[IndexInputConfig]
   private implicit val s3ConfigReader: TokensReader[S3Config] = ParserForClass[S3Config]
   private implicit val loggingConfigReader: TokensReader[LoggingConfig] = ParserForClass[LoggingConfig]
+  private implicit val jarIndexesConfigReader: TokensReader[JarIndexesConfig] = ParserForClass[JarIndexesConfig]
   implicit val parser: ParserForClass[MainConfig] = ParserForClass[MainConfig]
 }

--- a/src/main/scala/com/virtuslab/shared_indexes/core/SharedIndexes.scala
+++ b/src/main/scala/com/virtuslab/shared_indexes/core/SharedIndexes.scala
@@ -84,4 +84,17 @@ object SharedIndexes {
     }
   }
 
+  def key(jarPaths: Seq[os.Path]): String = {
+    jarPaths.map(digest).hashCode().toHexString
+  }
+
+  private def digest(f: os.Path): Int = {
+    // TODO implement fuzzy hashing
+    f.last.hashCode
+  }
+
+  def bestMatch(availableKeys: Seq[String], key: String): Option[String] = {
+    if (availableKeys contains key) Some(key) else None
+  }
+
 }


### PR DESCRIPTION
This is a proof of concept of managing the JAR indexes on a S3 server. Unfortunately, the Jetbrains tool doesn't support uploading JAR indexes to S3, so we have to do it manually.